### PR TITLE
[fix] bug 修复4带两对，带了个炸弹的情况。

### DIFF
--- a/douzero/env/move_detector.py
+++ b/douzero/env/move_detector.py
@@ -64,8 +64,7 @@ def get_move_type(move):
                 (count_dict.get(2) == 1 or count_dict.get(1) == 2):
             return {'type': TYPE_13_4_2, 'rank': move[2]}
 
-    if move_size == 8 and (((len(move_dict) == 3 or len(move_dict) == 2) and
-            (count_dict.get(4) == 1 and count_dict.get(2) == 2)) or count_dict.get(4) == 2):
+    if move_size == 8 and (len(move_dict) == 3 and (count_dict.get(4) == 1 and count_dict.get(2) == 2)):
         return {'type': TYPE_14_4_22, 'rank': max([c for c, n in move_dict.items() if n == 4])}
 
     mdkeys = sorted(move_dict.keys())


### PR DESCRIPTION
1. 依据 国家体育总局规则修复了 4带两对不能带炸弹的情况。https://max.book118.com/html/2019/0821/8067020103002043.shtm